### PR TITLE
feat: catch tracking service errors and show them to users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,14 +51,11 @@ ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
-# Install playwright browser
-RUN /app/.venv/bin/python -m playwright install chromium
-# RUN --mount=type=cache,target=/root/.cache/pip \
-#     pip install playwright
-# RUN playwright install chromium
-
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Install playwright browser
+RUN python -m playwright install chromium
 
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rahgiri Bot
 
-![](https://img.shields.io/badge/release-v0.2.0-blue)
+![](https://img.shields.io/badge/release-v0.3.0-blue)
 ![](https://img.shields.io/badge/python-3.11-green)
 
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __author__ = "Mehdi Samsami"

--- a/bot/utils/exceptions.py
+++ b/bot/utils/exceptions.py
@@ -1,0 +1,6 @@
+class TrackingError(Exception):
+    """
+    Exception raised when the tracking service returns an error.
+    """
+
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rahgiri-bot"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Telegram bot for tracking parcels via the Iran Post Tracking System."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "rahgiri-bot"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fake-useragent" },


### PR DESCRIPTION
- Added an exception class `TrackingError` for errors returned by the tracking service.
- Now a `TrackingError` is raised by the `track_parcel` function when the tracking service returns an error instead of parcel tracking records.
- Updated the `handle_tracking_process` handler to catch`TrackingError` and return its message to the user.
- Minor change in Dockerfile and `playwright install` command.