### PR TITLE
feat: proxy configuration for opening the tracking website

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TELEGRAM_TOKEN="*****************"
 TRACKING_TIMEOUT="15"
+PROXY_URL="socks5://127.0.0.1:1080"
 DEVELOPER_CHAT_ID="-100**********"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,32 +7,6 @@ WORKDIR /app
 # Allowing read, write, and execute permissions
 RUN chmod 777 /app
 
-# Install system dependencies required for Playwright and Chromium
-RUN apt-get update && apt-get install -y \
-    libglib2.0-0 \
-    libnss3 \
-    libnspr4 \
-    libdbus-1-3 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libgbm1 \
-    libasound2 \
-    libatspi2.0-0 \
-    libexpat1 \
-    libx11-6 \
-    libxcb1 \
-    libxext6 \
-    libxi6 \
-    libxtst6 \
-    && rm -rf /var/lib/apt/lists/*
-
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 
@@ -55,7 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Install playwright browser
-RUN python -m playwright install chromium
+RUN python -m playwright install chromium --with-deps
 
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rahgiri Bot
 
-![](https://img.shields.io/badge/release-v0.3.1-blue)
+![](https://img.shields.io/badge/release-v0.4.0-blue)
 ![](https://img.shields.io/badge/python-3.11-green)
 
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __author__ = "Mehdi Samsami"

--- a/bot/config.py
+++ b/bot/config.py
@@ -10,6 +10,9 @@ class Settings(BaseSettings):
     tracking_timeout: int | float = 15
     """Tracking timeout, in seconds."""
 
+    proxy_url: Optional[str] = None
+    """Proxy URL to use for opening the tracking website."""
+
     developer_chat_id: Optional[str] = None
     """Developer chat ID for error notifications."""
 

--- a/bot/handlers/tracking.py
+++ b/bot/handlers/tracking.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from playwright.async_api import ProxySettings
 from telegram import Message, Update
 from telegram.ext import (
     CallbackQueryHandler,
@@ -94,7 +95,12 @@ async def handle_tracking_process(update: Update, context: ContextTypes.DEFAULT_
 
         tracking_records: Optional[list[TrackingRecord]] = None
         try:
-            tracking_records = await track_parcel(tracking_number, timeout=settings.tracking_timeout, normalizer=normalize_text)
+            proxy = None
+            if settings.proxy_url:
+                proxy = ProxySettings(server=settings.proxy_url)
+            tracking_records = await track_parcel(
+                tracking_number, timeout=settings.tracking_timeout, normalizer=normalize_text, proxy=proxy
+            )
         except TrackingError as e:
             await update.message.reply_text(error_msg(str(e)))
         except Exception:

--- a/bot/utils/tracking.py
+++ b/bot/utils/tracking.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 from fake_useragent import UserAgent
-from playwright.async_api import async_playwright
+from playwright.async_api import ProxySettings, async_playwright
 
 from bot.models import TrackingRecord
 
@@ -63,6 +63,7 @@ async def track_parcel(
     tracking_number: str,
     timeout: Optional[float] = None,
     normalizer: Optional[Callable[[str], str]] = None,
+    proxy: Optional[ProxySettings] = None,
 ) -> list[TrackingRecord]:
     """Track a parcel using its tracking number by scraping the Iran Post Tracking website.
 
@@ -73,6 +74,7 @@ async def track_parcel(
         tracking_number (str): The tracking number of the parcel to be tracked.
         timeout (Optional[float]): The timeout for the tracking website to load, in seconds. Defaults to None for 30 seconds.
         normalizer (Optional[Callable[[str], str]]): A function to normalize the extracted text data. Defaults to None.
+        proxy (Optional[ProxySettings]): A proxy settings to use for opening the tracking website. Defaults to None.
 
     Returns:
         list[TrackingRecord]: A list of `TrackingRecord` items containing the parsed tracking records.
@@ -85,7 +87,7 @@ async def track_parcel(
 
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
-        context = await browser.new_context(user_agent=UserAgent().random)
+        context = await browser.new_context(user_agent=UserAgent().random, proxy=proxy)
         page = await context.new_page()
 
         # Open the post tracking website

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rahgiri-bot"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Telegram bot for tracking parcels via the Iran Post Tracking System."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "rahgiri-bot"
-version = "0.3.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fake-useragent" },


### PR DESCRIPTION
- Added support for using a proxy configuration to open the tracking website
- Simplified the _Dockerfile_ by using `--with-deps` arg for installing `playwright`'s dependencies instead of manual installation