### PR TITLE
feat: add support for image (screenshot) output type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - playwright>=1.49.1
           - pydantic-settings>=2.7.1
           - python-telegram-bot>=21.9
           - .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rahgiri Bot
 
-![](https://img.shields.io/badge/release-v0.4.0-blue)
+![](https://img.shields.io/badge/release-v0.5.0-blue)
 ![](https://img.shields.io/badge/python-3.11-green)
 
 
@@ -10,6 +10,7 @@ Rahgiri Bot is a Telegram bot that helps users track their parcels through the I
 ## Features
 - 📦 Track parcels using tracking numbers
 - 🔄 Real-time status updates
+- 📄 View tracking results in text or as image
 - 📝 Save and manage multiple tracking numbers (coming soon)
 - 🔔 Automatic status notifications (coming soon)
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Mehdi Samsami"

--- a/bot/enums.py
+++ b/bot/enums.py
@@ -4,4 +4,6 @@ from enum import Enum
 class Command(str, Enum):
     START = "start"
     TRACK = "track"
+    TRACK_OUTPUT_TEXT = "text"
+    TRACK_OUTPUT_IMAGE = "image"
     HELP = "help"

--- a/bot/handlers/help.py
+++ b/bot/handlers/help.py
@@ -14,9 +14,6 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     query = update.callback_query
     await query.answer()
 
-    if context.user_data is not None:
-        context.user_data.clear()
-
     help_text = "\n".join(
         [
             "📬 ربات تلگرام *رهگیری مرسولات پستی*\n",

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -3,6 +3,9 @@ from telegram.ext import ContextTypes
 
 from bot.keyboards.markups import keyboard_markup_start
 
+REDIRECT_FROM_TRACKING_KEY = "redirect_from_tracking"
+
+
 start_msg = "\n".join(
     [
         "سلام",
@@ -20,10 +23,21 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not update.message and not update.callback_query:
         return
 
+    redirect_to_start = False
     if context.user_data is not None:
+        redirect_to_start = context.user_data.get(REDIRECT_FROM_TRACKING_KEY, False)
         context.user_data.clear()
 
-    if update.message:
-        await update.message.reply_text(start_msg, reply_markup=keyboard_markup_start, parse_mode="markdown")
-    elif update.callback_query:
-        await update.callback_query.edit_message_text(start_msg, reply_markup=keyboard_markup_start, parse_mode="markdown")
+    if redirect_to_start:
+        if update.effective_chat:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text=start_msg,
+                reply_markup=keyboard_markup_start,
+                parse_mode="markdown",
+            )
+    else:
+        if update.message:
+            await update.message.reply_text(start_msg, reply_markup=keyboard_markup_start, parse_mode="markdown")
+        elif update.callback_query:
+            await update.callback_query.edit_message_text(start_msg, reply_markup=keyboard_markup_start, parse_mode="markdown")

--- a/bot/handlers/tracking.py
+++ b/bot/handlers/tracking.py
@@ -12,7 +12,11 @@ from telegram.ext import (
 
 from bot.config import settings
 from bot.enums import Command
-from bot.keyboards.markups import keyboard_markup_back
+from bot.keyboards.markups import (
+    OUTPUT_TYPE_CALLBACK_MAP,
+    keyboard_markup_back,
+    keyboard_markup_tracking_output_type,
+)
 from bot.models import TrackingRecord
 from bot.utils.exceptions import TrackingError
 from bot.utils.text import (
@@ -21,19 +25,20 @@ from bot.utils.text import (
     normalize_text,
     warning_msg,
 )
-from bot.utils.tracking import track_parcel, validate_tracking_number
+from bot.utils.tracking import ParcelTracker, validate_tracking_number
 
-from .start import handle_start
+from .start import REDIRECT_FROM_TRACKING_KEY, handle_start
 
-__all__ = ("handle_tracking_number", "handle_tracking_process", "tracking_conversation_handler")
+__all__ = ("tracking_conversation_handler",)
 
 
-START_TRACKING = 0
-IS_TRACKING_FLAG = "is_tracking"
+WAITING_FOR_TRACKING_NUMBER = 0
+WAITING_FOR_RESULT_TYPE = 1
+IS_TRACKING_FLAG_KEY = "is_tracking"
 LAST_MESSAGE_ID_KEY = "last_message_id"
 
 
-async def _delete_last_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def _remove_keyboard_markup(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if context.user_data is not None and (last_message_id := context.user_data.get(LAST_MESSAGE_ID_KEY)):
         if update.effective_chat:
             chat_id = update.effective_chat.id
@@ -41,7 +46,7 @@ async def _delete_last_message(update: Update, context: ContextTypes.DEFAULT_TYP
             chat_id = update.message.chat_id
         else:
             return
-        await context.bot.delete_message(chat_id=chat_id, message_id=last_message_id)
+        await context.bot.edit_message_reply_markup(chat_id=chat_id, message_id=last_message_id, reply_markup=None)
 
 
 def _end_conversation(context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -65,64 +70,114 @@ async def handle_tracking_number(update: Update, context: ContextTypes.DEFAULT_T
     else:
         return _end_conversation(context)
 
-    if context.user_data is not None:
-        context.user_data[IS_TRACKING_FLAG] = True
-        if isinstance(message, Message):
-            context.user_data[LAST_MESSAGE_ID_KEY] = message.message_id
+    if context.user_data is not None and isinstance(message, Message):
+        context.user_data[LAST_MESSAGE_ID_KEY] = message.message_id
 
-    return START_TRACKING
+    return WAITING_FOR_TRACKING_NUMBER
+
+
+async def handle_tracking_result_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """
+    Handler for selecting the type of the tracking result.
+    """
+    if not update.message or not context.user_data:
+        return _end_conversation(context)
+
+    await _remove_keyboard_markup(update, context)
+
+    tracking_number = str(update.message.text).strip()
+    if not validate_tracking_number(tracking_number):
+        await update.message.reply_text(error_msg("شماره رهگیری مرسوله معتبر نیست."))
+        await handle_tracking_number(update, context)
+        return WAITING_FOR_TRACKING_NUMBER
+
+    context.user_data["tracking_number"] = tracking_number
+
+    msg_text = "نوع نمایش نتیجه رهگیری را انتخاب کنید."
+    if update.message:
+        message = await update.message.reply_text(msg_text, reply_markup=keyboard_markup_tracking_output_type)
+    else:
+        return _end_conversation(context)
+
+    context.user_data[IS_TRACKING_FLAG_KEY] = True
+    if isinstance(message, Message):
+        context.user_data[LAST_MESSAGE_ID_KEY] = message.message_id
+
+    return WAITING_FOR_RESULT_TYPE
 
 
 async def handle_tracking_process(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """
     Handler for parcel tracking process.
     """
-    if not update.message or not context.user_data or not context.user_data.get(IS_TRACKING_FLAG):
+    query = update.callback_query
+    if not query or not context.user_data or not context.user_data.get(IS_TRACKING_FLAG_KEY):
         return _end_conversation(context)
 
-    tracking_number = str(update.message.text).strip()
+    await query.answer()
 
-    if not validate_tracking_number(tracking_number):
-        await update.message.reply_text(error_msg("شماره رهگیری مرسوله معتبر نیست."))
-        await _delete_last_message(update, context)
-        await handle_tracking_number(update, context)
-        return START_TRACKING
+    if not query.message or not query.data:
+        return _end_conversation(context)
 
-    else:
-        context.user_data.pop(IS_TRACKING_FLAG, None)
-        await _delete_last_message(update, context)
-        await update.message.reply_text("🔄 در حال رهگیری...", quote=True)
+    result_type = query.data
+    tracking_number = str(context.user_data.get("tracking_number")).strip()
 
-        tracking_records: Optional[list[TrackingRecord]] = None
-        try:
-            proxy = None
-            if settings.proxy_url:
-                proxy = ProxySettings(server=settings.proxy_url)
-            tracking_records = await track_parcel(
-                tracking_number, timeout=settings.tracking_timeout, normalizer=normalize_text, proxy=proxy
+    context.user_data.pop(IS_TRACKING_FLAG_KEY, None)
+    await _remove_keyboard_markup(update, context)
+    result_type_fa = OUTPUT_TYPE_CALLBACK_MAP.get(result_type, "تصویر")
+    await context.bot.send_message(
+        chat_id=query.message.chat.id,
+        text="\n\n".join(["🔄 در حال رهگیری...", f"(نوع نمایش: *{result_type_fa}*)"]),
+        parse_mode="markdown",
+    )
+
+    tracking_result: Optional[list[TrackingRecord] | bytes] = None
+    try:
+        proxy = None
+        if settings.proxy_url:
+            proxy = ProxySettings(server=settings.proxy_url)
+
+        return_type = result_type if result_type in ("text", "image") else "image"
+
+        tracker = ParcelTracker(normalizer=normalize_text, proxy=proxy)
+        if return_type == "image":
+            tracking_result = await tracker.track_as_image(tracking_number, timeout=settings.tracking_timeout)
+        else:
+            tracking_result = await tracker.track_as_text(tracking_number, timeout=settings.tracking_timeout)
+    except TrackingError as e:
+        await context.bot.send_message(chat_id=query.message.chat.id, text=error_msg(str(e)))
+    except Exception:
+        await context.bot.send_message(
+            chat_id=query.message.chat.id, text=error_msg("عملیات با خطا مواجه شد. لطفا دقایقی دیگر مجددا تلاش کنید.")
+        )
+        context.user_data[REDIRECT_FROM_TRACKING_KEY] = True
+        await handle_start(update, context)
+        _end_conversation(context)
+        raise
+
+    if tracking_result is not None:
+        if isinstance(tracking_result, bytes):
+            await context.bot.send_photo(
+                chat_id=query.message.chat.id,
+                photo=tracking_result,
+                caption=f"✅ شماره رهگیری: *{tracking_number}*",
+                parse_mode="markdown",
             )
-        except TrackingError as e:
-            await update.message.reply_text(error_msg(str(e)))
-        except Exception:
-            await update.message.reply_text(error_msg("عملیات با خطا مواجه شد. لطفا دقایقی دیگر مجددا تلاش کنید."))
-            await handle_start(update, context)
-            _end_conversation(context)
-            raise
-
-        if tracking_records is not None:
-            if tracking_records:
+        else:
+            if tracking_result:
                 reply_text = "\n\n".join(
                     [
                         f"✅ شماره رهگیری: *{tracking_number}*",
                     ]
-                    + [format_tracking_record(record) for record in tracking_records]
+                    + [format_tracking_record(record) for record in tracking_result]
                 )
-                await update.message.reply_text(reply_text, parse_mode="markdown")
+                await context.bot.send_message(chat_id=query.message.chat.id, text=reply_text, parse_mode="markdown")
             else:
-                await update.message.reply_text(warning_msg("نتیجه ای یافت نشد!"))
+                await context.bot.send_message(chat_id=query.message.chat.id, text=warning_msg("نتیجه ای یافت نشد!"))
 
-        await handle_start(update, context)
-        return _end_conversation(context)
+    context.user_data[REDIRECT_FROM_TRACKING_KEY] = True
+    await handle_start(update, context)
+    return _end_conversation(context)
 
 
 tracking_conversation_handler = ConversationHandler(
@@ -130,8 +185,13 @@ tracking_conversation_handler = ConversationHandler(
         CallbackQueryHandler(handle_tracking_number, pattern=Command.TRACK),
     ],
     states={
-        START_TRACKING: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, handle_tracking_process),
+        WAITING_FOR_TRACKING_NUMBER: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, handle_tracking_result_type),
+        ],
+        WAITING_FOR_RESULT_TYPE: [
+            CallbackQueryHandler(
+                handle_tracking_process, pattern=f"^(?:{Command.TRACK_OUTPUT_TEXT.value}|{Command.TRACK_OUTPUT_IMAGE.value})$"
+            ),
         ],
     },
     fallbacks=[

--- a/bot/keyboards/markups.py
+++ b/bot/keyboards/markups.py
@@ -2,10 +2,24 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from bot.enums import Command
 
+OUTPUT_TYPE_CALLBACK_MAP: dict[str | Command, str] = {
+    Command.TRACK_OUTPUT_TEXT: "متن",
+    Command.TRACK_OUTPUT_IMAGE: "عکس",
+}
+
+
 keyboard_markup_start = InlineKeyboardMarkup(
     [
         [InlineKeyboardButton("رهگیری مرسوله", callback_data=Command.TRACK)],
         [InlineKeyboardButton("راهنما", callback_data=Command.HELP)],
+    ]
+)
+
+
+keyboard_markup_tracking_output_type = InlineKeyboardMarkup(
+    [
+        [InlineKeyboardButton(text, callback_data=callback_data) for callback_data, text in OUTPUT_TYPE_CALLBACK_MAP.items()],
+        [InlineKeyboardButton("بازگشت", callback_data=Command.START)],
     ]
 )
 

--- a/bot/utils/tracking.py
+++ b/bot/utils/tracking.py
@@ -1,13 +1,20 @@
-from typing import Callable, Optional
+from contextlib import asynccontextmanager, suppress
+from typing import AsyncGenerator, Callable, Optional
 
 from fake_useragent import UserAgent
-from playwright.async_api import ProxySettings, async_playwright
+from playwright.async_api import (
+    ElementHandle,
+    Page,
+    ProxySettings,
+    ViewportSize,
+    async_playwright,
+)
 
 from bot.models import TrackingRecord
 
 from .exceptions import TrackingError
 
-__all__ = ("validate_tracking_number", "track_parcel")
+__all__ = ("validate_tracking_number", "ParcelTracker")
 
 
 def validate_tracking_number(tracking_number: str) -> bool:
@@ -25,101 +32,139 @@ def validate_tracking_number(tracking_number: str) -> bool:
     return len(tracking_number) == 24 and tracking_number.isdigit()
 
 
-def _parse_tracking_result(result: list[str], sep: str) -> list[TrackingRecord]:
-    items: list[TrackingRecord] = []
-
-    date: Optional[str] = None
-
-    for item in result:
-        if "موقعیت" in item and "ساعت" in item:
-            date = item.split(sep)[0]
-            continue
-
-        parts = [part.strip() for part in item.split(sep)]
-
-        if len(parts) == 3:
-            record = TrackingRecord(
-                id=int(parts[0]),
-                time=parts[2],
-                description=parts[1],
-            )
-        elif len(parts) == 4:
-            record = TrackingRecord(
-                id=int(parts[0]),
-                time=parts[3],
-                location=parts[2],
-                description=parts[1],
-            )
-
-        if date:
-            record.date = date
-
-        items.append(record)
-
-    return items
-
-
-async def track_parcel(
-    tracking_number: str,
-    timeout: Optional[float] = None,
-    normalizer: Optional[Callable[[str], str]] = None,
-    proxy: Optional[ProxySettings] = None,
-) -> list[TrackingRecord]:
-    """Track a parcel using its tracking number by scraping the Iran Post Tracking website.
-
-    This function uses Playwright to automate a browser session to fetch tracking information
-    from the tracking website. It processes the data to extract and return relevant tracking records.
+class ParcelTracker:
+    """
+    A class to track parcels using the Iran Post Tracking website. Provides methods
+    to scrape the tracking website and fetch parcel tracking details as text records or as a screenshot image.
 
     Args:
-        tracking_number (str): The tracking number of the parcel to be tracked.
-        timeout (Optional[float]): The timeout for the tracking website to load, in seconds. Defaults to None for 30 seconds.
         normalizer (Optional[Callable[[str], str]]): A function to normalize the extracted text data. Defaults to None.
-        proxy (Optional[ProxySettings]): A proxy settings to use for opening the tracking website. Defaults to None.
-
-    Returns:
-        list[TrackingRecord]: A list of `TrackingRecord` items containing the parsed tracking records.
-
-    Raises:
-        TrackingError: If the tracking service returns an error message. The error message is returned as the exception message.
+        proxy (Optional[ProxySettings]): Proxy settings for web scraping requests. Defaults to None.
     """
-    result: list[str] = []
-    sep = " | "
 
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        context = await browser.new_context(user_agent=UserAgent().random, proxy=proxy)
-        page = await context.new_page()
+    def __init__(self, normalizer: Optional[Callable[[str], str]] = None, proxy: Optional[ProxySettings] = None) -> None:
+        self.normalizer = normalizer
+        self.proxy = proxy
+        self._sep = " | "
 
-        # Open the post tracking website
+    @asynccontextmanager
+    async def _open_tracking_page(self, tracking_number: str, timeout: Optional[float]) -> AsyncGenerator[Page, None]:
         timeout_ms = timeout * 1000 if timeout else None
-        await page.goto(f"https://tracking.post.ir/?id={tracking_number}", wait_until="load", timeout=timeout_ms)
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(args=["--no-sandbox", "--disable-setuid-sandbox"], headless=True)
+            try:
+                context = await browser.new_context(user_agent=UserAgent().random, proxy=self.proxy)
+                page = await context.new_page()
+                await page.goto(f"https://tracking.post.ir/?id={tracking_number}", wait_until="load", timeout=timeout_ms)
+            except Exception:
+                await browser.close()
+                raise
+            yield page
+            await browser.close()
 
-        # Clicking the search button
+    async def _extract_tracking_rows(self, page: Page) -> list[ElementHandle]:
         await page.click("#btnSearch")
-
-        # Wait for the tracking result to load
         await page.wait_for_selector("#pnlMain")
 
-        # Fetch all divs with class 'row'
         all_row_divs = await page.query_selector_all("#pnlResult div.row")
 
-        # Check if the tracking service returned an error message
         if not all_row_divs:
             alert_divs = await page.query_selector_all("#pnlResult div.alert")
             if alert_divs:
                 raise TrackingError(await alert_divs[0].text_content())
 
-        # Extract and clean data from each row
-        for div in all_row_divs:
+        return all_row_divs
+
+    @staticmethod
+    def _parse_tracking_result(result: list[str], sep: str) -> list[TrackingRecord]:
+        items: list[TrackingRecord] = []
+
+        date: Optional[str] = None
+
+        for item in result:
+            if "موقعیت" in item and "ساعت" in item:
+                date = item.split(sep)[0]
+                continue
+
+            parts = [part.strip() for part in item.split(sep)]
+
+            if len(parts) == 3:
+                record = TrackingRecord(
+                    id=int(parts[0]),
+                    time=parts[2],
+                    description=parts[1],
+                )
+            elif len(parts) == 4:
+                record = TrackingRecord(
+                    id=int(parts[0]),
+                    time=parts[3],
+                    location=parts[2],
+                    description=parts[1],
+                )
+
+            if date:
+                record.date = date
+
+            items.append(record)
+
+        return items
+
+    async def _extract_tracking_records(self, tracking_rows: list[ElementHandle]) -> list[TrackingRecord]:
+        result: list[str] = []
+        for div in tracking_rows:
             columns = await div.query_selector_all("div.newtddata")
             if not columns:
                 columns = await div.query_selector_all("div.newtdheader")
             row_data = [await column.text_content() for column in columns]
             if not row_data:
                 continue
-            result.append(sep.join(data.strip() for data in row_data if data))
+            result.append(self._sep.join(value.strip() for value in row_data if value))
 
-    if result and normalizer:
-        result = [normalizer(item) for item in result]
+        if not result:
+            return []
 
-    return _parse_tracking_result(result, sep)
+        if self.normalizer:
+            result = [self.normalizer(item) for item in result]
+
+        return self._parse_tracking_result(result, self._sep)
+
+    async def track_as_text(self, tracking_number: str, timeout: Optional[float] = None) -> list[TrackingRecord]:
+        """Fetch tracking details as structured text records.
+
+        Args:
+            tracking_number (str): The tracking number of the parcel.
+            timeout (Optional[float]): Timeout for loading the tracking website, in seconds. Defaults to None.
+
+        Returns:
+            list[TrackingRecord]: A list of `TrackingRecord` items containing tracking details.
+
+        Raises:
+            TrackingError: Raised when the tracking service returns an error. The exception message provides the tracking error message.
+        """
+        async with self._open_tracking_page(tracking_number, timeout) as page:
+            tracking_rows = await self._extract_tracking_rows(page)
+            return await self._extract_tracking_records(tracking_rows)
+
+    async def track_as_image(self, tracking_number: str, timeout: Optional[float] = None) -> bytes:
+        """Fetch tracking details as a screenshot image.
+
+        Args:
+            tracking_number (str): The tracking number of the parcel.
+            timeout (Optional[float]): Timeout for loading the tracking website, in seconds. Defaults to None.
+
+        Returns:
+            bytes: The screenshot of the tracking website in PNG format.
+
+        Raises:
+            TrackingError: Raised when the tracking service returns an error. The exception message provides the tracking error message.
+        """
+        async with self._open_tracking_page(tracking_number, timeout) as page:
+            await self._extract_tracking_rows(page)
+            content_height = 2000
+            with suppress(Exception):
+                content_height = await page.evaluate("document.documentElement.scrollHeight")
+            await page.set_viewport_size(ViewportSize(width=1920, height=content_height))
+            return await page.screenshot(type="png")
+
+    def __repr__(self) -> str:
+        return f"ParcelTracker<(normalizer={self.normalizer}, proxy={self.proxy})>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rahgiri-bot"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Telegram bot for tracking parcels via the Iran Post Tracking System."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "rahgiri-bot"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fake-useragent" },


### PR DESCRIPTION
- Introduced support for image (screenshot) as tracking output type in the bot.
- Refactored the `track_parcel` function into a new class (`ParcelTracker`) to enhance modularity and support new output types.
- Added a new interactive keyboard for users to select the tracking output type.
- Modified handlers to process user preferences for the tracking output type.
- Added playwright to `mypy` dependencies in _.pre-commit-config.yaml_ file.